### PR TITLE
docs: align Foreman product descriptions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman",
-  "description": "Project continuity and roadmap trust: keeps a correctable roadmap in your repo, recommends the next task and says why it came first, and hands it off with the paths and symbols checked. Say what you want in plain language — one entrance routes it.",
+  "description": "Project continuity for Claude Code: a roadmap beside your code, grounded handoffs, and clear task status.",
   "license": "MIT",
   "author": {
     "name": "Victor Villegas",

--- a/tests/entrance.test.js
+++ b/tests/entrance.test.js
@@ -82,7 +82,7 @@ describe("specialized skills present as advanced surfaces", () => {
     const manifest = JSON.parse(
       fs.readFileSync(path.join(__dirname, "..", ".claude-plugin", "plugin.json"), "utf-8")
     );
-    assert.match(manifest.description, /^Project continuity and roadmap trust/);
+    assert.match(manifest.description, /^Project continuity.*roadmap/);
     assert.doesNotMatch(manifest.description, /[Pp]rompt-engineering/);
     assert.equal(manifest.keywords[0], "roadmap");
     assert.ok(!manifest.keywords.includes("prompt-engineering"));


### PR DESCRIPTION
Align Foreman's package descriptions with its existing README and GitHub promise: continuity between sessions, a roadmap beside the code, grounded handoffs and clear task status. The Codex card uses concrete product language. The Claude description assertion now checks the intended roadmap-first meaning rather than the retired sentence.

Validation: Claude/Codex README parity and Codex manifest validation passed. Required local suites passed: 1,204 Claude tests and 1,339 Codex tests. Product runtime is unchanged.

Foundry-README-Peer: #19@cd8e57b85616026ad6b47289b1d0a73e57f1287b

