### PR TITLE
docs: align Foreman product descriptions

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "foreman",
   "version": "3.0.4-codex.1",
-  "description": "Project continuity for Codex: maintain a correctable roadmap, choose useful work, and craft grounded handoffs with verifiable completion evidence.",
+  "description": "Project continuity for Codex: a roadmap beside your code, grounded handoffs, and clear task status.",
   "author": {
     "name": "Victor Villegas",
     "email": "victor.villegas@tuta.com"
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Foreman",
-    "shortDescription": "A roadmap that stays grounded in your code",
-    "longDescription": "Keep your plan beside the code, reconcile stale work, and turn tasks into checked Codex prompts. Preserve commit evidence, acceptance, and optional lessons across sessions.",
+    "shortDescription": "Keep your plan beside your code",
+    "longDescription": "Keep a roadmap beside your code, choose the next task and prepare a handoff checked against the project. Carry task status and evidence between sessions; acceptance remains a separate decision.",
     "developerName": "Victor Villegas",
     "category": "Productivity",
     "capabilities": [


### PR DESCRIPTION
Align Foreman's package descriptions with its existing README and GitHub promise: continuity between sessions, a roadmap beside the code, grounded handoffs and clear task status. The Codex card uses concrete product language. The Claude description assertion now checks the intended roadmap-first meaning rather than the retired sentence.

Validation: Claude/Codex README parity and Codex manifest validation passed. Required local suites passed: 1,204 Claude tests and 1,339 Codex tests. Product runtime is unchanged.

Foundry-README-Peer: #18@3fd617f17dd4eae854552eac6a7a41a114a850e4

